### PR TITLE
CI dev version fix

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -32,7 +32,7 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_PAT }}
 
       - name: Set dcsa-event-core mvn version variable
-        run: cd DCSA-Event-Core && echo "DCSA_EVENT_CORE_PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)- " >> $GITHUB_ENV
+        run: cd DCSA-Event-Core && echo "DCSA_EVENT_CORE_PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout -Dchangelist='')- " >> $GITHUB_ENV
 
       - run: echo $DCSA_EVENT_CORE_PROJECT_VERSION
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,8 @@
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>11</java.version>
-		<dcsa.events.version>0.0.50</dcsa.events.version>
-		<dcsa.core.tag/>
-		<dcsa.event.tag>-dev-bkg</dcsa.event.tag>
+		<dcsa.events.version>0.0.51</dcsa.events.version>
+		<dcsa.event.tag/>
 		<dcsa.artifacttype>-SNAPSHOT</dcsa.artifacttype>
 		<org.mapstruct.version>1.4.2.Final</org.mapstruct.version>
 		<org.lombok.version>1.18.22</org.lombok.version>


### PR DESCRIPTION
The dev CI for DCSA-Core and DCSA-Event-Core has been updated to build using dev branches.

We do not need `<dcsa.event.tag>-dev-bkg</dcsa.event.tag>`  anymore. 

To run the project locally and resolve the dependencies , 
1) Clone required branches of DCSA-Core and DCSA-Event-Core.
2) Run command `mvn clean install -nsu` for both DCSA-Core and DCSA-Event-Core.

This will install the dependencies in your local maven repo and resolve the dependency errors in DCSA-BKG.

FYR the main changes made in the dev CI,

DCSA-Event-Core:
-  [Set Dcsa-Core branch](https://github.com/dcsaorg/DCSA-Event-Core/blob/9751d50cff793b3e23290a0026cea0052962d53d/.github/workflows/PublishDevSnapshot.yml#L32)
- [Publish package](https://github.com/dcsaorg/DCSA-Event-Core/blob/9751d50cff793b3e23290a0026cea0052962d53d/.github/workflows/PublishDevSnapshot.yml#L54) (injects the required dsca-core properties during deployment)

DCSA-Core:
- [CI to deploy package for dev branches](https://github.com/dcsaorg/DCSA-Core/blob/dev-bkg/.github/workflows/PublishDevSnapshot.yml)
